### PR TITLE
Add YAML Library Support

### DIFF
--- a/FtRandoLib.csproj
+++ b/FtRandoLib.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,11 +8,15 @@
     <Description>A .NET class library of support functions for importing FamiTracker music into NES ROMs and maintaining music libraries, allowing support for FamiTracker conversions to be integrated into randomizers with minimal game-specific code.</Description>
     <PackageProjectUrl>https://github.com/TheRealQuantam/FtRandoLib</PackageProjectUrl>
     <RepositoryUrl>https://github.com/TheRealQuantam/FtRandoLib</RepositoryUrl>
-    <IsTrimmable>True</IsTrimmable>
+    <IsTrimmable>False</IsTrimmable>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\$(Configuration)\$(TargetFramework)</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <!--<PackageReference Include="Vecc.YamlDotNet.Analyzers.StaticGenerator" Version="16.3.0" />-->
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
 <ItemGroup>

--- a/Importer/Importer.cs
+++ b/Importer/Importer.cs
@@ -1,11 +1,11 @@
 using FtRandoLib.Library;
 using FtRandoLib.Utility;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using YamlDotNet.Serialization;
 
 namespace FtRandoLib.Importer;
 
@@ -173,12 +173,35 @@ public abstract class Importer
         where TItem : MusicFileInfo
         where TGroup : GroupInfo<TItem>
     {
-        return (LibraryInfo<TItem, TGroup>)LibraryInfo<TItem, TGroup>.Parse<LibraryInfo<TItem, TGroup>>(
+        return LibraryInfo<TItem, TGroup>.ParseJson<LibraryInfo<TItem, TGroup>>(
             jsonData, 
             (opts ?? DefaultParserOptions).IgnoreExtraFields);
     }
 
-    protected IEnumerable<TSong> LoadJsonGroupSongs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TSong, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup>(
+    public LibraryInfo<TItem, TGroup> ParseYamlLibrary<TItem, TGroup>(
+        string yamlData,
+        LibraryParserOptions? opts = null)
+        where TItem : MusicFileInfo
+        where TGroup : GroupInfo<TItem>
+    {
+        return LibraryInfo<TItem, TGroup>.ParseYaml<LibraryInfo<TItem, TGroup>>(
+            yamlData,
+            (opts ?? DefaultParserOptions).IgnoreExtraFields);
+    }
+
+    public LibraryInfo<TItem, TGroup> ParseYamlLibrary<TItem, TGroup, TContext>(
+        string yamlData,
+        LibraryParserOptions? opts = null)
+        where TItem : MusicFileInfo
+        where TGroup : GroupInfo<TItem>
+        where TContext : StaticContext, new()
+    {
+        return LibraryInfo<TItem, TGroup>.ParseYaml<LibraryInfo<TItem, TGroup>, TContext>(
+            yamlData,
+            (opts ?? DefaultParserOptions).IgnoreExtraFields);
+    }
+
+    protected IEnumerable<TSong> LoadGroupSongs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TSong, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup>(
         IEnumerable<TItem> songs,
         Func<TGroup?, IEnumerable<TItem>, LibraryParserOptions?, IEnumerable<TSong>> LoadSongs,
         TGroup? group = null,
@@ -199,7 +222,7 @@ public abstract class Importer
         }
     }
 
-    protected IEnumerable<TSong> LoadJsonLibrarySongs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TSong, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup>(
+    protected IEnumerable<TSong> LoadLibrarySongs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TSong, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup>(
         LibraryInfo<TItem, TGroup> libObj,
         Func<TGroup?, IEnumerable<TItem>, LibraryParserOptions?, IEnumerable<TSong>> LoadSongs,
         LibraryParserOptions? opts = null)
@@ -208,9 +231,9 @@ public abstract class Importer
         where TGroup : GroupInfo<TItem>
     {
         List<TSong> songs = new();
-        songs.AddRange(LoadJsonGroupSongs(libObj.Single, LoadSongs, null, opts));
+        songs.AddRange(LoadGroupSongs(libObj.Single, LoadSongs, null, opts));
         foreach (var grp in libObj.Groups)
-            songs.AddRange(LoadJsonGroupSongs(grp.Items, LoadSongs, grp, opts));
+            songs.AddRange(LoadGroupSongs(grp.Items, LoadSongs, grp, opts));
 
         return songs;
     }
@@ -224,7 +247,7 @@ public abstract class Importer
         where TGroup : GroupInfo<TItem>
     {
         var libObj = ParseJsonLibrary<TItem, TGroup>(jsonData, opts);
-        return LoadJsonLibrarySongs(libObj, LoadSongs, opts);
+        return LoadLibrarySongs(libObj, LoadSongs, opts);
     }
 
     public IEnumerable<FtSong> LoadFtJsonLibrarySongs(
@@ -233,6 +256,47 @@ public abstract class Importer
     {
         return LoadJsonLibrarySongs<FtSong, FtModuleInfo, FtModuleGroupInfo>(jsonData, LoadFtSongs, opts);
     }
+
+    protected IEnumerable<TSong> LoadYamlLibrarySongs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TSong, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup>(
+        string yamlData,
+        Func<TGroup?, IEnumerable<TItem>, LibraryParserOptions?, IEnumerable<TSong>> LoadSongs,
+        LibraryParserOptions? opts = null)
+        where TSong : ISong
+        where TItem : MusicFileInfo
+        where TGroup : GroupInfo<TItem>
+    {
+        var libObj = ParseYamlLibrary<TItem, TGroup>(
+            yamlData, opts);
+        return LoadLibrarySongs(libObj, LoadSongs, opts);
+    }
+
+    public IEnumerable<FtSong> LoadFtYamlLibrarySongs(
+        string yamlData,
+        LibraryParserOptions? opts = null)
+    {
+        return LoadYamlLibrarySongs<FtSong, FtModuleInfo, FtModuleGroupInfo>(yamlData, LoadFtSongs, opts);
+    }
+
+    protected IEnumerable<TSong> LoadYamlLibrarySongs<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TSong, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup, TContext>(
+        string yamlData,
+        Func<TGroup?, IEnumerable<TItem>, LibraryParserOptions?, IEnumerable<TSong>> LoadSongs,
+        LibraryParserOptions? opts = null)
+        where TSong : ISong
+        where TItem : MusicFileInfo
+        where TGroup : GroupInfo<TItem>
+        where TContext : StaticContext, new()
+    {
+        var libObj = ParseYamlLibrary<TItem, TGroup, TContext>(
+            yamlData, opts);
+        return LoadLibrarySongs(libObj, LoadSongs, opts);
+    }
+
+    /*public IEnumerable<FtSong> LoadFtYamlLibrarySongs(
+        string yamlData,
+        LibraryParserOptions? opts = null)
+    {
+        return LoadYamlLibrarySongs<FtSong, FtModuleInfo, FtModuleGroupInfo>(yamlData, LoadFtSongs, opts);
+    }*/
 
     protected IEnumerable<FtSong> LoadFtSongs(
         FtModuleGroupInfo? grpInfo,

--- a/Importer/Importer.cs
+++ b/Importer/Importer.cs
@@ -101,6 +101,11 @@ public record SongMapInfo(string Name, int Offset, int Length, byte EmptyIndex =
 
 public abstract class Importer
 {
+    public static IReadOnlySet<string> JsonExtensions()
+        => MusicFileInfo.JsonExtensions();
+    public static IReadOnlySet<string> YamlExtensions()
+        => MusicFileInfo.YamlExtensions();
+    
     /// <summary>
     /// The size of each ROM bank
     /// </summary>

--- a/Library/Errors.cs
+++ b/Library/Errors.cs
@@ -3,35 +3,18 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text;
+using YamlDotNet.Core;
 
 namespace FtRandoLib.Library;
 
 /// <summary>
-/// An error that occurred during LibraryInfo.Parse - either a JSON parsing error or data format error.
+/// An error that occurred during LibraryInfo.Parse - either a parsing error or data format error.
 /// </summary>
-public class ParsingError : Exception
+public class ParsingError : BaseParsingError
 {
-    /// <summary>
-    /// If the JSON parsing error was caused by something else - e.g. a base-64 format error - contains the Message from that error.
-    /// </summary>
-    public string? Submessage { get; }
-
-    /// <summary>
-    /// The JSON line number the error occurred at, or 0 if unknown.
-    /// </summary>
-    public int LineNum { get; }
-
-    /// <summary>
-    /// The column at which the error occurred, or 0 if unknown.
-    /// </summary>
-    public int ColumnNum { get; }
-
-    /// <summary>
-    /// The JSON hierarchy path to the node causing the error, e.g. single[0].title, or null if unknown.
-    /// </summary>
-    public string? Path { get; }
-
     /// <summary>
     /// The type of the item (e.g. module) contained in the library being parsed.
     /// </summary>
@@ -43,31 +26,66 @@ public class ParsingError : Exception
     public Type GroupType { get; }
 
     /// <summary>
-    /// The object being parsed at the time of error, or null if unknown.
-    /// </summary>
-    public object? Object { get; }
-
-    /// <summary>
-    /// The name of the field in the object which caused the error, or null if unknown.
-    /// </summary>
-    public string? FieldName { get; }
-
-    /// <summary>
     /// A composite string that can be displayed in error messages indicating where the error occurred, or null if no location information is known.
     /// </summary>
-    public string? AtString { get; }
+    public string? AtString
+    {
+        get
+        {
+            if (!_atStringBuilt)
+            {
+                _atString = BuildAtString();
+                _atStringBuilt = true;
+            }
 
-    public static void Throw<TItem, TGroup>(
-        object? sender,
-        Newtonsoft.Json.Serialization.ErrorEventArgs args)
-        => throw new ParsingError(typeof(TItem), typeof(TGroup), sender, args);
+            return _atString;
+        }
+    }
+
+    string? _atString = null;
+    bool _atStringBuilt = false;
+
+    public ParsingError(
+        string? message,
+        Type itemType,
+        Type groupType,
+        Exception? innerException)
+        : base(message, innerException)
+    {
+        ItemType = itemType;
+        GroupType = groupType;
+    }
+
+    public ParsingError(
+        BaseParsingError source,
+        string? message,
+        Type itemType,
+        Type groupType,
+        Exception? innerException = null)
+        : base(source, message, innerException)
+    {
+        ItemType = itemType;
+        GroupType = groupType;
+    }
+
+    public ParsingError(
+        BaseParsingError source,
+        Type itemType,
+        Type groupType)
+        : this(source,
+              source.Message,
+              itemType,
+              groupType,
+              source.InnerException)
+    { }
 
     public ParsingError(
         Type itemType, 
         Type groupType,
         object? sender, 
         Newtonsoft.Json.Serialization.ErrorEventArgs args)
-        : base(TrimMessage(args.ErrorContext.Error.Message), args.ErrorContext.Error)
+        : base(TrimMessage(args.ErrorContext.Error.Message),
+            innerException: args.ErrorContext.Error)
     {
         var ctx = args.ErrorContext;
         var ex = ctx.Error;
@@ -89,8 +107,32 @@ public class ParsingError : Exception
             LineNum = readEx.LineNumber;
             ColumnNum = readEx.LinePosition;
         }
+    }
 
-        AtString = BuildAtString();
+    [DoesNotReturn]
+    public static void Throw<TItem, TGroup>(
+        object? sender,
+        Newtonsoft.Json.Serialization.ErrorEventArgs args)
+        => throw new ParsingError(typeof(TItem), typeof(TGroup), sender, args);
+
+    [DoesNotReturn]
+    public static void Throw<TItem, TGroup>(YamlException yamlEx)
+    {
+        Exception ex = yamlEx;
+        if (ex.InnerException is not null)
+            ex = ex.InnerException;
+        if (ex is TargetInvocationException
+            && ex.InnerException is not null)
+            ex = ex.InnerException;
+        if (ex is ParsingError)
+            throw ex;
+
+        throw new ParsingError(
+            ex.Message, typeof(TItem), typeof(TGroup), ex.InnerException)
+        {
+            LineNum = checked((int)yamlEx.Start.Line),
+            ColumnNum = checked((int)yamlEx.Start.Column),
+        };
     }
 
     /// <summary>

--- a/Library/Errors/BaseParsingError.cs
+++ b/Library/Errors/BaseParsingError.cs
@@ -1,0 +1,63 @@
+﻿using System;
+
+namespace FtRandoLib.Library;
+
+/// <summary>
+/// The base form of a ParsingError that can be thrown directly, without needing to know the types involved in deserialization. This should be caught at the appropriate level and converted into a proper ParsingError.
+/// </summary>
+public class BaseParsingError : Exception
+{
+    /// <summary>
+    /// If the parsing error was caused by something else - e.g. a base-64 format error - contains the Message from that error.
+    /// </summary>
+    public string? Submessage { get; init; } = null;
+
+    /// <summary>
+    /// The line number the error occurred at, or 0 if unknown.
+    /// </summary>
+    public int LineNum { get; init; } = 1;
+
+    /// <summary>
+    /// The column at which the error occurred, or 0 if unknown.
+    /// </summary>
+    public int ColumnNum { get; init; } = 1;
+
+    /// <summary>
+    /// The hierarchy path to the node causing the error, e.g. single[0].title, or null if unknown.
+    /// </summary>
+    public string? Path { get; init; } = null;
+
+    /// <summary>
+    /// The object being parsed at the time of error, or null if unknown.
+    /// </summary>
+    public object? Object { get; init; } = null;
+
+    /// <summary>
+    /// The name of the field in the object which caused the error, or null if unknown.
+    /// </summary>
+    public string? FieldName { get; init; } = null;
+
+    public BaseParsingError(
+        string? message = null, 
+        Exception? innerException = null)
+        : base(message, innerException)
+    { }
+
+    protected BaseParsingError(
+        BaseParsingError source,
+        string? message,
+        Exception? innerException = null)
+        : this(message, innerException)
+    {
+        Submessage = source.Submessage;
+        LineNum = source.LineNum;
+        ColumnNum = source.ColumnNum;
+        Path = source.Path;
+        Object = source.Object;
+        FieldName = source.FieldName;
+    }
+
+    protected BaseParsingError(BaseParsingError source)
+        : this(source.Message, source.InnerException)
+    { }
+}

--- a/Library/SoundTrack.cs
+++ b/Library/SoundTrack.cs
@@ -91,6 +91,11 @@ public abstract class MusicInfo
 /// </summary>
 public abstract class MusicFileInfo : MusicInfo
 {
+    public static IReadOnlySet<string> JsonExtensions() 
+        => new IstringSet([".json", ".jsonc", ".cjson", ".json5"]);
+    public static IReadOnlySet<string> YamlExtensions() 
+        => new IstringSet([".yaml", ".yml"]);
+
     /// <summary>
     /// The logical address of the start of the file data. This is used in rebasing the data to be placed in a different location in memory.
     /// </summary>

--- a/Library/SoundTrack.cs
+++ b/Library/SoundTrack.cs
@@ -4,10 +4,16 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using YamlDotNet.Serialization.NodeDeserializers;
 
 namespace FtRandoLib.Library;
 
@@ -16,12 +22,10 @@ namespace FtRandoLib.Library;
 /// </summary>
 public class JsonHexStringConverter : JsonConverter
 {
-    public override bool CanWrite { get { return false; } }
+    public override bool CanWrite => false;
 
     public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 
     public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
     {
@@ -37,9 +41,7 @@ public class JsonHexStringConverter : JsonConverter
     }
 
     public override bool CanConvert(Type objectType)
-    {
-        throw new NotImplementedException();
-    }
+        => throw new NotImplementedException();
 }
 
 /// <summary>
@@ -47,15 +49,11 @@ public class JsonHexStringConverter : JsonConverter
 /// </summary>
 public abstract class MusicInfo
 {
-    /*[JsonIgnore]
-    public const bool EnabledDefault = true;
-    [JsonIgnore]
-    public const bool StreamingSafeDefault = true;*/
-
     [JsonProperty("enabled")]
     public bool? Enabled { get; set; } = null;
 
     [JsonProperty("title", Required = Required.Always)]
+    [Required]
     public string Title { get; set; } = "";
 
     [JsonProperty("author")]
@@ -65,7 +63,7 @@ public abstract class MusicInfo
     /// Miscellaneous string tags of mostly application-specific uses. Tags with no or a '+' prefix are added to the tags of their parents, while tags with a '-' prefix are removed.
     /// </summary>
     [JsonProperty("tags")]
-    public IstringSet Tags { get; } = new();
+    public IstringSet Tags { get; set; } = new();
 
     /// <summary>
     /// Whether or not the item is likely to be caught by stream scanners and have negative implications for the stream.
@@ -83,7 +81,7 @@ public abstract class MusicInfo
     /// The uses in the randomizer this song may be selected for.
     /// </summary>
     [JsonProperty("uses")]
-    public IstringSet Uses { get; } = new();
+    public IstringSet Uses { get; set; } = new();
 
     public override string ToString() => $"{GetType().Name} : \"{Title}\"";
 }
@@ -98,12 +96,14 @@ public abstract class MusicFileInfo : MusicInfo
     /// </summary>
     [JsonProperty("start_addr")]
     [JsonConverter(typeof(JsonHexStringConverter))]
+    [YamlConverter(typeof(YamlHexStringConverter))]
     public int? StartAddr { get; set; } = null;
 
     /// <summary>
     /// The data in the form provided by the library file. The base implementation encodes this data in base64 (.NET dialect), optionally compressed via deflate (.NET dialect) if the data begins with "deflate:".
     /// </summary>
     [JsonProperty("data", Required = Required.Always)]
+    [Required]
     public string Data
     {
         get { return data; }
@@ -118,9 +118,12 @@ public abstract class MusicFileInfo : MusicInfo
     /// The decoded and decompressed data.
     /// </summary>
     [JsonIgnore]
-    public byte[] UncompressedData { get; private set; } = new byte[0];
+    [YamlIgnore]
+    [MinLength(1, ErrorMessage = "The Data field is required")]
+    public byte[] UncompressedData { get; private set; } = Array.Empty<byte>();
 
     [JsonIgnore]
+    [YamlIgnore]
     public int Size { get { return UncompressedData.Length; } }
 
     private string data = "";
@@ -158,19 +161,22 @@ public abstract class MusicFileInfo : MusicInfo
 /// A FamiTracker song in the library.
 /// </summary>
 [JsonObject]
+[YamlSerializable]
 public class FtSongInfo : MusicInfo
 {
     /// <summary>
     /// The 0-based index of the song in the containing module.
     /// </summary>
     [JsonProperty("number", Required = Required.Always)]
-    public int Number { get; set; } = 0;
+    [Range(0, int.MaxValue, ErrorMessage = "The " + nameof(Number) + " field is required")]
+    public int Number { get; set; } = -1;
 }
 
 /// <summary>
 /// A FamiTracker module in the library.
 /// </summary>
 [JsonObject]
+[YamlSerializable]
 public class FtModuleInfo : MusicFileInfo
 {
     [DynamicDependency(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(FtSongInfo))]
@@ -189,6 +195,7 @@ public class FtModuleInfo : MusicFileInfo
 /// </summary>
 /// <typeparam name="TItem">The type of object in the group.</typeparam>
 [JsonObject]
+[YamlSerializable]
 public class GroupInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem> : MusicInfo 
     where TItem : MusicFileInfo
 {
@@ -202,6 +209,7 @@ public class GroupInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberType
 /// <typeparam name="TItem">The file type of the library.</typeparam>
 /// <typeparam name="TGroup">The file group type of the library.</typeparam>
 [JsonObject]
+[YamlSerializable]
 public class LibraryInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TItem, 
     [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TGroup> 
     where TItem : MusicFileInfo 
@@ -214,19 +222,56 @@ public class LibraryInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     public List<TGroup> Groups { get; set; } = new();
 
     /// <summary>
+    /// Parse a JSON or YAML file into a LibraryInfo. It is preferable to use ParseJson or ParseYaml as Parse is not 100% guaranteed to correctly detect the file format.
+    /// </summary>
+    /// <param name="data">The JSON or YAML data to parse.</param>
+    /// <param name="type">The type to construct. Must be the class through which Parse is called or a subclass of it.</param>
+    /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
+    public static object Parse(
+        string data,
+        Type type,
+        bool ignoreExtraFields = false)
+    {
+        Debug.Assert(type.IsAssignableTo(typeof(LibraryInfo<TItem, TGroup>)));
+
+        if (IsFirstCharJson(data.First(ch => char.IsWhiteSpace(ch))))
+            return ParseJson(data, type, ignoreExtraFields);
+        else
+            return ParseYaml(data, type, ignoreExtraFields);
+    }
+
+    /// <summary>
+    /// Parse a JSON or YAML file into a LibraryInfo. It is preferable to use ParseJson or ParseYaml as Parse is not 100% guaranteed to correctly detect the file format.
+    /// </summary>
+    /// <typeparam name="TLibrary">The type to construct. Must be the class through which Parse is called or a subclass of it.</typeparam>
+    /// <param name="data">The JSON or YAML data to parse.</param>
+    /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
+    /// <returns></returns>
+    public static TLibrary Parse<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TLibrary>(
+        string data,
+        bool ignoreExtraFields = false)
+        where TLibrary : LibraryInfo<TItem, TGroup>
+    {
+        if (IsFirstCharJson(data.First(ch => char.IsWhiteSpace(ch))))
+            return ParseJson<TLibrary>(data, ignoreExtraFields);
+        else
+            return ParseYaml<TLibrary>(data, ignoreExtraFields);
+    }
+
+    /// <summary>
     /// Parse a JSON file into a LibraryInfo. Should be used when loading libraries to ensure that errors are properly translated into ParsingErrors.
     /// </summary>
     /// <param name="jsonData">The JSON data to parse.</param>
     /// <param name="type">The type to construct. Must be the class through which Parse is called or a subclass of it.</param>
     /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
-    public static object Parse(
+    public static object ParseJson(
         string jsonData,
         Type type,
         bool ignoreExtraFields = false)
     {
         Debug.Assert(type.IsAssignableTo(typeof(LibraryInfo<TItem, TGroup>)));
 
-        return Parse<object>(jsonData,
+        return ParseJson<object>(jsonData,
             (j, s) => JsonConvert.DeserializeObject(j, type, s),
             ignoreExtraFields);
     }
@@ -238,15 +283,88 @@ public class LibraryInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
     /// <param name="jsonData">The JSON data to parse.</param>
     /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
     /// <returns></returns>
-    public static TLibrary Parse<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TLibrary>(
+    public static TLibrary ParseJson<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] TLibrary>(
         string jsonData,
         bool ignoreExtraFields = false)
         where TLibrary : LibraryInfo<TItem, TGroup>
-        => Parse<TLibrary>(jsonData, 
-            (j, s) => JsonConvert.DeserializeObject<TLibrary>(j, s), 
+        => ParseJson<TLibrary>(jsonData,
+            (j, s) => JsonConvert.DeserializeObject<TLibrary>(j, s),
             ignoreExtraFields);
 
-    static TLibrary Parse<TLibrary>(
+    /// <summary>
+    /// Parse a YAML file into a LibraryInfo. Should be used when loading libraries to ensure that errors are properly translated into ParsingErrors.
+    /// </summary>
+    /// <param name="yamlData">The YAML data to parse.</param>
+    /// <param name="type">The type to construct. Must be the class through which Parse is called or a subclass of it.</param>
+    /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
+    public static object ParseYaml(
+        string yamlData,
+        Type type,
+        bool ignoreExtraFields = false)
+    {
+        Debug.Assert(type.IsAssignableTo(typeof(LibraryInfo<TItem, TGroup>)));
+
+        var builder = new DeserializerBuilder()
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .WithTypeConverter(new YamlHexStringConverter())
+            .WithNodeDeserializer(
+                i => new ValidatingYamlNodeDeserializer(i), 
+                s => s.InsteadOf<ObjectNodeDeserializer>());
+
+        if (ignoreExtraFields)
+            builder = builder.IgnoreUnmatchedProperties();
+
+        var deserializer = builder.Build();
+        return DeserializeYaml<object>(yamlData,
+            d => deserializer.Deserialize(d, type));
+    }
+
+    /// <summary>
+    /// Parse a YAML file into a LibraryInfo. Should be used when loading libraries to ensure that errors are properly translated into ParsingErrors. This version of ParseYaml is not trimming safe.
+    /// </summary>
+    /// <typeparam name="TLibrary">The type to construct. Must be the class through which Parse is called or a subclass of it.</typeparam>
+    /// <param name="yamlData">The YAML data to parse.</param>
+    /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
+    /// <returns></returns>
+    public static TLibrary ParseYaml<TLibrary>(
+        string yamlData,
+        bool ignoreExtraFields = false)
+        where TLibrary : LibraryInfo<TItem, TGroup>
+        => (TLibrary)ParseYaml(yamlData, typeof(TLibrary), ignoreExtraFields);
+
+    /// <summary>
+    /// Parse a YAML file into a LibraryInfo. Should be used when loading libraries to ensure that errors are properly translated into ParsingErrors.
+    /// </summary>
+    /// <typeparam name="TLibrary">The type to construct. Must be the class through which Parse is called or a subclass of it.</typeparam>
+    /// <typeparam name="TContext">A YamlDotNet StaticContext capable of parsing a TLibrary.</typeparam>
+    /// <param name="yamlData">The YAML data to parse.</param>
+    /// <param name="ignoreExtraFields">Whether to ignore fields that are not defined in the class. Defaults to false: throw an error if extra fields are present.</param>
+    /// <returns></returns>
+    public static TLibrary ParseYaml<TLibrary, TContext>(
+        string yamlData,
+        bool ignoreExtraFields = false)
+        where TLibrary : LibraryInfo<TItem, TGroup>
+        where TContext : StaticContext, new()
+    {
+        var builder = new StaticDeserializerBuilder(new TContext())
+            .WithNamingConvention(UnderscoredNamingConvention.Instance)
+            .WithTypeConverter(new YamlHexStringConverter())
+            .WithNodeDeserializer(
+                i => new ValidatingYamlNodeDeserializer(i),
+                s => s.InsteadOf<ObjectNodeDeserializer>());
+
+        if (ignoreExtraFields)
+            builder = builder.IgnoreUnmatchedProperties();
+
+        var deserializer = builder.Build();
+        return DeserializeYaml<TLibrary>(yamlData,
+            d => deserializer.Deserialize<TLibrary>(d));
+    }
+
+    static bool IsFirstCharJson(char ch)
+        => ch == '[' || ch == '{';
+
+    static TLibrary ParseJson<TLibrary>(
         string jsonData,
         Func<string, JsonSerializerSettings, TLibrary?> ParsePrimitive,
         bool ignoreExtraFields = false)
@@ -279,8 +397,34 @@ public class LibraryInfo<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTy
                 throw;
         }
     }
+
+    static TLibrary DeserializeYaml<TLibrary>(
+        string yamlData,
+        Func<string, TLibrary?> ParsePrimitive)
+    {
+        try
+        {
+            var value = ParsePrimitive(yamlData);
+            Debug.Assert(value is not null); ////
+
+            return value;
+        }
+        catch (YamlException e)
+        {
+            if (e.InnerException is BaseParsingError parseErr)
+                throw new ParsingError(
+                    parseErr, typeof(TItem), typeof(TGroup));
+            else
+                ParsingError.Throw<TItem, TGroup>(e);
+
+            // Shut up compiler
+            throw new UnreachableException();
+        }
+    }
 }
 
+[JsonObject]
+[YamlSerializable]
 public sealed class FtModuleGroupInfo : GroupInfo<FtModuleInfo> 
 {
     [DynamicDependency(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(FtModuleInfo))]
@@ -288,6 +432,8 @@ public sealed class FtModuleGroupInfo : GroupInfo<FtModuleInfo>
     { }
 }
 
+[JsonObject]
+[YamlSerializable]
 public sealed class FtLibraryInfo : LibraryInfo<FtModuleInfo, FtModuleGroupInfo> 
 {
     [DynamicDependency(DynamicallyAccessedMemberTypes.All | DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof(FtModuleGroupInfo))]

--- a/Library/YAML/ValidatingYamlNodeDeserializer.cs
+++ b/Library/YAML/ValidatingYamlNodeDeserializer.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace FtRandoLib.Library;
+
+/// <summary>
+/// YamlDotNet does not have a built-in mechanism to require that fields be present, so it must be implemented here.
+/// </summary>
+public class ValidatingYamlNodeDeserializer : INodeDeserializer
+{
+    readonly INodeDeserializer _inner;
+    readonly List<ValidationResult> _valResults = new();
+
+    public ValidatingYamlNodeDeserializer(INodeDeserializer inner)
+    {
+        _inner = inner;
+    }
+
+    public bool Deserialize(IParser reader,
+        Type expectedType,
+        Func<IParser, Type, object?> nestedObjectDeserializer,
+        out object? value,
+        ObjectDeserializer rootDeserializer)
+    {
+        value = null;
+
+        var evt = reader.Current!;
+        YamlException? yamlEx = null;
+
+        try
+        {
+            if (!_inner.Deserialize(
+                reader,
+                expectedType,
+                nestedObjectDeserializer,
+                out value,
+                rootDeserializer))
+                return false; // Not an object
+        }
+        catch (YamlException e)
+        {
+            // An error occurred deserializing the object
+            yamlEx = e;
+        }
+
+        if (value is not null)
+        {
+            bool throwEx = false;
+            string? errMsg = null, fieldName = null;
+            Mark mark = Mark.Empty;
+            if (yamlEx != null)
+            {
+                Exception e = yamlEx;
+                if (e.InnerException is not null)
+                    e = e.InnerException;
+                if (e is TargetInvocationException
+                    && e.InnerException is not null)
+                    e = e.InnerException;
+                if (e is BaseParsingError)
+                    throw e;
+
+                errMsg = e.Message;
+                mark = yamlEx.Start;
+                //fieldName = 
+
+                throwEx = true;
+            }
+            else
+            {
+                _valResults.Clear();
+                if (!Validator.TryValidateObject(
+                    value, new(value), _valResults, true))
+                {
+                    var res = _valResults[0];
+                    
+                    errMsg = res.ErrorMessage;
+                    fieldName = res.MemberNames.FirstOrDefault();
+                    mark = evt.Start;
+                    throwEx = true;
+                }
+            }
+
+            if (throwEx)
+                throw new BaseParsingError(errMsg)
+                {
+                    LineNum = checked((int)mark.Line),
+                    ColumnNum = checked((int)mark.Column),
+                    Object = value,
+                    FieldName = fieldName,
+                };
+        }
+
+        return true;
+    }
+}

--- a/Library/YAML/YamlHexStringConverter.cs
+++ b/Library/YAML/YamlHexStringConverter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Globalization;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+/// <summary>
+/// IYamlTypeConverter that allows a number to be specified either as decimal or a hex value prefixed with either $ or 0x.
+/// </summary>
+public class YamlHexStringConverter : IYamlTypeConverter
+{
+    static readonly string[] HexPrefixes = ["$", "0x"];
+
+    public YamlHexStringConverter()
+    { }
+
+    public bool Accepts(Type type)
+        => false;
+
+    public object? ReadYaml(
+        IParser parser,
+        Type type,
+        ObjectDeserializer deserializer)
+    {
+        Scalar scalar = parser.Consume<Scalar>();
+        string valStr = scalar.Value;
+        bool isHex = false;
+
+        foreach (string pre in HexPrefixes)
+        {
+            if (valStr.StartsWith(pre))
+            {
+                valStr = valStr.Substring(pre.Length);
+                isHex = true;
+
+                break;
+            }
+        }
+
+        return int.Parse(valStr,
+            isHex ? NumberStyles.HexNumber : NumberStyles.Integer);
+    }
+
+    public void WriteYaml(
+        IEmitter emitter,
+        object? value,
+        Type type,
+        ObjectSerializer serializer)
+        => throw new NotImplementedException();
+}
+

--- a/Test/LibraryTests.cs
+++ b/Test/LibraryTests.cs
@@ -20,6 +20,7 @@ public class LibraryTests
                     author: "Author",
                     primary_square_chan: 0,
                     uses: ["1", "2"],
+                    start_addr: 1000,
                     data: "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8=",
                 },
             ],
@@ -38,6 +39,7 @@ public class LibraryTests
                             author: "Author1",
                             primary_square_chan: 1,
                             uses: ["1", "2"],
+                            start_addr: "1000",
                             data: "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8=",
                         },
                         {
@@ -54,13 +56,13 @@ public class LibraryTests
         }
         """, 0, 1)]
     [Theory]
-    public void LoadLibraryImmediateSucceeds(
+    public void LoadJsonLibraryImmediateSucceeds(
         string _, // Test name
         string jsonData,
         int numSingle,
         int numGroups)
     {
-        var lib = LoadLibrary(jsonData);
+        var lib = LoadJsonLibrary(jsonData);
 
         Assert.Equal(lib.Single.Count, numSingle);
         Assert.Equal(lib.Groups.Count, numGroups);
@@ -155,7 +157,7 @@ public class LibraryTests
         "could not find member 'goat'",
         new string[] { "line 9", "position 21", "with title 'Title'" })]
     [Theory]
-    public void LoadLibraryImmediateFails(
+    public void LoadJsonLibraryImmediateFails(
         string _, // Test name
         string jsonData,
         object? errRegex = null,
@@ -163,11 +165,135 @@ public class LibraryTests
         RegexOptions? regexOpts = null,
         RegexOptions? atRegexOpts = null)
     {
-        var ex = Assert.Throws<ParsingError>(() => LoadLibrary(jsonData));
+        var ex = Assert.Throws<ParsingError>(() => LoadJsonLibrary(jsonData));
      
         AssertRegexMatches(
             $"{ex.Message}\n{ex.Submessage ?? string.Empty}", 
             errRegex, 
+            regexOpts);
+
+        AssertRegexMatches(ex.AtString, atRegex, atRegexOpts);
+    }
+
+    [InlineData("single", """
+        single:
+            -   title: Title
+                author: 'Author'
+                primary_square_chan: 0
+                uses: [1, "2"]
+                start_addr: 1000
+                data: EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8=
+        """, 1, 0)]
+    [InlineData("groups", """
+        groups:
+            -   title: "Group"
+                author: "Author"
+                primary_square_chan: "0"
+                items:
+                    -   title: "Title1"
+                        author: "Author1"
+                        primary_square_chan: 1
+                        uses: 
+                            - 1
+                            - "2"
+                        start_addr: 0x1000
+                        data: "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8="
+                    -   title: "Title2"
+                        start_addr: $1000
+                        data: "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8="
+                    -   title: "Title3"
+                        start_addr: "1000"
+                        start_addr: "0x1000"
+                        start_addr: "$1000"
+                        data: "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8="
+        """, 0, 1)]
+    [Theory]
+    public void LoadYamlLibraryImmediateSucceeds(
+        string _, // Test name
+        string yamlData,
+        int numSingle,
+        int numGroups)
+    {
+        var lib = LoadYamlLibrary(yamlData);
+
+        Assert.Equal(lib.Single.Count, numSingle);
+        Assert.Equal(lib.Groups.Count, numGroups);
+    }
+
+    [InlineData(
+        "string assigned to int",
+        """
+        single:
+            -   title: "Title"
+                author: "Author"
+                primary_square_chan: goat
+                uses: ["1", "2"]
+                "data": "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8="
+        """,
+        "not in a correct format",
+        new string[] { "line 4", "position 30", "with title 'Title'" })]
+    [InlineData(
+        "invalid base64",
+        """
+        single:
+            -   title: "Title"
+                author: "Author"
+                primary_square_chan: 0
+                uses: ["1", "2"]
+                "data": "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8"
+        """,
+        new string[] { /*"Error setting value to 'Data'",*/ "not a valid Base-64 string" },
+        new string[] { "line 6", "position 9", "with title 'Title'" })]
+    [InlineData(
+        "invalid deflate",
+        """
+        single:
+            -   title: "Title"
+                author: "Author"
+                primary_square_chan: 0
+                uses: ["1", "2"]
+                "data": "deflate:EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8="
+        """,
+        new string[] { /*"Error setting value to 'Data'",*/ "unsupported compression method" },
+        new string[] { "line 6", "position 9", "with title 'Title'" })]
+    [InlineData(
+        "missing field",
+        """
+        single:
+            -   title: "Title"
+                author: "Author"
+                primary_square_chan: 0
+                uses: ["1", "2"]
+        """,
+        "The Data field is required.",
+        new string[] { "line 2", "position 9", "with title 'Title'" })]
+    [InlineData(
+        "extra field",
+        """
+        single:
+            -   title: "Title"
+                author: "Author"
+                primary_square_chan: 0
+                uses: ["1", "2"]
+                "data": "EAAPAA8ADwAPAAAQDrgLABIAGgABQAaWAAAcACYAKgAqACoAKgCIAAA/AD8="
+                goat: true
+        """,
+        "Property 'goat' not found",
+        new string[] { "line 7", "position 9", "with title 'Title'" })]
+    [Theory]
+    public void LoadYamlLibraryImmediateFails(
+        string _, // Test name
+        string yamlData,
+        object? errRegex = null,
+        object? atRegex = null,
+        RegexOptions? regexOpts = null,
+        RegexOptions? atRegexOpts = null)
+    {
+        var ex = Assert.Throws<ParsingError>(() => LoadYamlLibrary(yamlData));
+
+        AssertRegexMatches(
+            $"{ex.Message}\n{ex.Submessage ?? string.Empty}",
+            errRegex,
             regexOpts);
 
         AssertRegexMatches(ex.AtString, atRegex, atRegexOpts);
@@ -209,7 +335,7 @@ public class LibraryTests
             Assert.True(ex.Groups[0].Items[0].Tags.SetEquals(tags));
         }
     }*/
-    
+
     /*[Theory]
     public void LoadLibrarySucceeds(
         string path,
@@ -251,15 +377,27 @@ public class LibraryTests
     }
 
 
-    private FtLibraryInfo LoadLibrary(string jsonData)
+    private FtLibraryInfo LoadJsonLibrary(string jsonData)
     {
-        return (FtLibraryInfo)FtLibraryInfo.Parse<FtLibraryInfo>(jsonData);
+        return (FtLibraryInfo)FtLibraryInfo.ParseJson<FtLibraryInfo>(jsonData);
     }
 
-    private FtLibraryInfo LoadLibraryFile(string path)
+    private FtLibraryInfo LoadJsonLibraryFile(string path)
     {
         string jsonData = File.ReadAllText(path);
         
-        return LoadLibrary(jsonData);
+        return LoadJsonLibrary(jsonData);
+    }
+
+    private FtLibraryInfo LoadYamlLibrary(string jsonData)
+    {
+        return (FtLibraryInfo)FtLibraryInfo.ParseYaml<FtLibraryInfo>(jsonData);
+    }
+
+    private FtLibraryInfo LoadYamlLibraryFile(string path)
+    {
+        string yamlData = File.ReadAllText(path);
+
+        return LoadYamlLibrary(yamlData);
     }
 }


### PR DESCRIPTION
Add support for library files in YAML format. This will hopefully provide a superior way of creating libraries files, eliminating the out of spec JSON/JSON5 behavior and switching to a less verbose and more permissive format for non-programmers.